### PR TITLE
feat: add .groverc driven copy rules for add

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ Track a remote branch:
 grove add feature/new-feature --track origin/feature/new-feature
 ```
 
+To copy files when creating a worktree, configure copy rules in a project-level `.groverc` (JSON) file:
+
+```json
+{
+  "copy": {
+    "from": "main",
+    "include": [".env", "apps/*/.env"],
+    "exclude": ["apps/web/.env.local"]
+  }
+}
+```
+
+- `copy.from`: source worktree name (for example `main`) or `cwd`
+- `copy.include`: required patterns to copy (bare names like `.env` or `Taskfile.yaml` are recursive, like `**/.env` and `**/Taskfile.yaml`)
+- `copy.exclude`: optional glob patterns to skip
+- `.git` is always excluded
+
 ### Remove a worktree
 
 Remove a worktree:

--- a/site/index.html
+++ b/site/index.html
@@ -798,6 +798,15 @@ $ grove go main`;
                     <pre><code>grove add feature-branch</code></pre>
                     <p>With tracking for a remote branch:</p>
                     <pre><code>grove add feature-branch --track origin/feature-branch</code></pre>
+                    <p>Copy behavior is configured in <code>.groverc</code> (JSON):</p>
+                    <pre><code>{
+  "copy": {
+    "from": "main",
+    "include": [".env", "apps/*/.env"],
+    "exclude": ["apps/web/.env.local"]
+  }
+}</code></pre>
+                    <p>Note: bare names in <code>include</code> (like <code>.env</code> or <code>Taskfile.yaml</code>) are treated recursively.</p>
                 </div>
 
                 <div class="command-group">

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,11 +1,18 @@
 import { Command } from "commander";
 import * as path from "path";
+import * as fs from "fs/promises";
 import chalk from "chalk";
 import { WorktreeManager } from "../git/WorktreeManager";
 import { handleCommandError } from "../utils";
 
 interface AddCommandOptions {
   track?: string;
+}
+
+interface GrovercCopyConfig {
+  from?: string;
+  include: string[];
+  exclude?: string[];
 }
 
 export function createAddCommand(): Command {
@@ -78,6 +85,18 @@ async function runAdd(name: string, options: AddCommandOptions): Promise<void> {
     console.log(chalk.green("✓ Created worktree:"), chalk.bold(name));
   }
   console.log(chalk.gray("  Path:"), worktreePath);
+
+  const copyConfig = await readGrovercCopyConfig(projectRoot);
+  if (copyConfig) {
+    const sourceDir = await resolveCopySourceDirectory(copyConfig, manager);
+    const copiedCount = await copyConfiguredEntries(copyConfig, sourceDir, worktreePath);
+    if (copiedCount > 0) {
+      console.log(chalk.gray("  Copied configured entries:"), copiedCount);
+      console.log(chalk.gray("  Copy source:"), sourceDir);
+    } else {
+      console.log(chalk.gray("  No files matched .groverc copy rules."));
+    }
+  }
 }
 
 function getWorktreePath(branchName: string, projectRoot: string): string {
@@ -103,4 +122,145 @@ function getWorktreePath(branchName: string, projectRoot: string): string {
   }
 
   return resolvedPath;
+}
+
+export async function readGrovercCopyConfig(projectRoot: string): Promise<GrovercCopyConfig | null> {
+  const configPath = path.join(projectRoot, ".groverc");
+  let configContent: string;
+
+  try {
+    configContent = await fs.readFile(configPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`Failed to read .groverc: ${error}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configContent);
+  } catch (error) {
+    throw new Error(`Invalid .groverc JSON: ${error}`);
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid .groverc: expected a JSON object.");
+  }
+
+  const copy = (parsed as { copy?: unknown }).copy;
+  if (copy === undefined) {
+    return null;
+  }
+  if (!copy || typeof copy !== "object") {
+    throw new Error("Invalid .groverc copy config: expected an object.");
+  }
+
+  const from = (copy as { from?: unknown }).from;
+  if (from !== undefined && typeof from !== "string") {
+    throw new Error("Invalid .groverc copy.from: expected a string.");
+  }
+
+  const include = (copy as { include?: unknown }).include;
+  if (!Array.isArray(include) || include.length === 0 || !include.every((entry) => typeof entry === "string" && entry.trim().length > 0)) {
+    throw new Error("Invalid .groverc copy.include: expected a non-empty array of strings.");
+  }
+
+  const exclude = (copy as { exclude?: unknown }).exclude;
+  if (exclude !== undefined && (!Array.isArray(exclude) || !exclude.every((entry) => typeof entry === "string" && entry.trim().length > 0))) {
+    throw new Error("Invalid .groverc copy.exclude: expected an array of strings.");
+  }
+
+  return {
+    from,
+    include,
+    exclude,
+  };
+}
+
+async function resolveCopySourceDirectory(copyConfig: GrovercCopyConfig, manager: WorktreeManager): Promise<string> {
+  const source = copyConfig.from?.trim();
+  if (!source || source === "cwd") {
+    return process.cwd();
+  }
+
+  const sourceWorktree = await manager.findWorktreeByName(source);
+  if (!sourceWorktree) {
+    throw new Error(`Configured copy source '${source}' was not found as a worktree.`);
+  }
+
+  return sourceWorktree.path;
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function isGitMetadataPath(relativePath: string): boolean {
+  return relativePath === ".git" || relativePath.startsWith(".git/");
+}
+
+function hasGlobMagic(pattern: string): boolean {
+  return /[*?[\]{}()!+@]/.test(pattern);
+}
+
+function shouldExpandBareNamePatternRecursively(pattern: string): boolean {
+  return !pattern.includes("/") && !pattern.includes("\\");
+}
+
+export async function copyConfiguredEntries(
+  copyConfig: GrovercCopyConfig,
+  sourceDir: string,
+  targetDir: string,
+): Promise<number> {
+  if (path.resolve(sourceDir) === path.resolve(targetDir)) {
+    return 0;
+  }
+
+  const includeMatches = new Set<string>();
+  for (const pattern of copyConfig.include) {
+    const patternsToScan = [pattern];
+    if (shouldExpandBareNamePatternRecursively(pattern)) {
+      patternsToScan.push(`**/${pattern}`);
+    }
+
+    let matched = false;
+    for (const scanPattern of patternsToScan) {
+      const glob = new Bun.Glob(scanPattern);
+      for await (const relativePath of glob.scan({ cwd: sourceDir, dot: true })) {
+        matched = true;
+        includeMatches.add(normalizeRelativePath(relativePath));
+      }
+    }
+
+    if (!matched && !hasGlobMagic(pattern)) {
+      const normalizedPath = normalizeRelativePath(pattern);
+      const explicitPath = path.join(sourceDir, normalizedPath);
+      try {
+        await fs.stat(explicitPath);
+        includeMatches.add(normalizedPath);
+      } catch {
+        // Explicit path does not exist; continue to next pattern.
+      }
+    }
+  }
+
+  const excludeGlobs = (copyConfig.exclude ?? []).map((pattern) => new Bun.Glob(pattern));
+  const toCopy = [...includeMatches]
+    .filter((relativePath) => !isGitMetadataPath(relativePath))
+    .filter((relativePath) => !excludeGlobs.some((glob) => glob.match(relativePath)))
+    .sort();
+
+  for (const relativePath of toCopy) {
+    const sourcePath = path.join(sourceDir, relativePath);
+    const targetPath = path.join(targetDir, relativePath);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.cp(sourcePath, targetPath, {
+      recursive: true,
+      force: false,
+      errorOnExist: false,
+    });
+  }
+
+  return toCopy.length;
 }

--- a/test/unit/add.test.ts
+++ b/test/unit/add.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import {
+  copyConfiguredEntries,
+  readGrovercCopyConfig,
+} from "../../src/commands/add";
+
+async function createTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe("readGrovercCopyConfig", () => {
+  test("returns null when .groverc does not exist", async () => {
+    const projectRoot = await createTempDir("grove-groverc-none-");
+    const config = await readGrovercCopyConfig(projectRoot);
+    expect(config).toBeNull();
+  });
+
+  test("parses valid copy config", async () => {
+    const projectRoot = await createTempDir("grove-groverc-valid-");
+    await fs.writeFile(
+      path.join(projectRoot, ".groverc"),
+      JSON.stringify({
+        copy: {
+          from: "main",
+          include: ["apps/*/.env", ".env"],
+          exclude: ["apps/web/.env.local"],
+        },
+      }),
+    );
+
+    const config = await readGrovercCopyConfig(projectRoot);
+
+    expect(config).not.toBeNull();
+    expect(config?.from).toBe("main");
+    expect(config?.include).toEqual(["apps/*/.env", ".env"]);
+    expect(config?.exclude).toEqual(["apps/web/.env.local"]);
+  });
+
+  test("throws for invalid include config", async () => {
+    const projectRoot = await createTempDir("grove-groverc-invalid-");
+    await fs.writeFile(
+      path.join(projectRoot, ".groverc"),
+      JSON.stringify({ copy: { include: [] } }),
+    );
+
+    await expect(readGrovercCopyConfig(projectRoot)).rejects.toThrow(
+      "Invalid .groverc copy.include",
+    );
+  });
+});
+
+describe("copyConfiguredEntries", () => {
+  test("treats bare file names as recursive (e.g. Taskfile.yaml)", async () => {
+    const sourceDir = await createTempDir("grove-copy-source-taskfile-");
+    const targetDir = await createTempDir("grove-copy-target-taskfile-");
+
+    await fs.mkdir(path.join(sourceDir, "apps", "web"), { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "Taskfile.yaml"), "version: '3'\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "web", "Taskfile.yaml"), "version: '3'\n");
+
+    const copiedCount = await copyConfiguredEntries(
+      {
+        include: ["Taskfile.yaml"],
+      },
+      sourceDir,
+      targetDir,
+    );
+
+    expect(copiedCount).toBe(2);
+
+    const rootTaskfile = await fs.readFile(path.join(targetDir, "Taskfile.yaml"), "utf8");
+    expect(rootTaskfile).toContain("version:");
+
+    const nestedTaskfile = await fs.readFile(path.join(targetDir, "apps", "web", "Taskfile.yaml"), "utf8");
+    expect(nestedTaskfile).toContain("version:");
+  });
+
+  test("treats '.env' include as recursive across monorepo directories", async () => {
+    const sourceDir = await createTempDir("grove-copy-source-env-");
+    const targetDir = await createTempDir("grove-copy-target-env-");
+
+    await fs.mkdir(path.join(sourceDir, "apps", "web"), { recursive: true });
+    await fs.mkdir(path.join(sourceDir, "apps", "api"), { recursive: true });
+
+    await fs.writeFile(path.join(sourceDir, ".env"), "ROOT=1\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "web", ".env"), "WEB=1\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "api", ".env"), "API=1\n");
+
+    const copiedCount = await copyConfiguredEntries(
+      {
+        include: [".env"],
+      },
+      sourceDir,
+      targetDir,
+    );
+
+    expect(copiedCount).toBe(3);
+
+    const rootEnv = await fs.readFile(path.join(targetDir, ".env"), "utf8");
+    expect(rootEnv).toContain("ROOT=1");
+
+    const webEnv = await fs.readFile(path.join(targetDir, "apps", "web", ".env"), "utf8");
+    expect(webEnv).toContain("WEB=1");
+
+    const apiEnv = await fs.readFile(path.join(targetDir, "apps", "api", ".env"), "utf8");
+    expect(apiEnv).toContain("API=1");
+  });
+
+  test("copies explicit directory includes without glob syntax", async () => {
+    const sourceDir = await createTempDir("grove-copy-source-dir-");
+    const targetDir = await createTempDir("grove-copy-target-dir-");
+
+    await fs.mkdir(path.join(sourceDir, ".vscode"), { recursive: true });
+    await fs.writeFile(path.join(sourceDir, ".vscode", "settings.json"), "{\"a\":1}\n");
+
+    const copiedCount = await copyConfiguredEntries(
+      {
+        include: [".vscode"],
+      },
+      sourceDir,
+      targetDir,
+    );
+
+    expect(copiedCount).toBe(1);
+
+    const content = await fs.readFile(path.join(targetDir, ".vscode", "settings.json"), "utf8");
+    expect(content).toContain("\"a\":1");
+  });
+
+  test("copies include matches and respects exclude + .git skip", async () => {
+    const sourceDir = await createTempDir("grove-copy-source-");
+    const targetDir = await createTempDir("grove-copy-target-");
+
+    await fs.mkdir(path.join(sourceDir, "apps", "web"), { recursive: true });
+    await fs.mkdir(path.join(sourceDir, "apps", "api"), { recursive: true });
+    await fs.mkdir(path.join(sourceDir, ".git"), { recursive: true });
+
+    await fs.writeFile(path.join(sourceDir, ".env"), "ROOT=1\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "web", ".env"), "WEB=1\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "web", ".env.local"), "WEB_LOCAL=1\n");
+    await fs.writeFile(path.join(sourceDir, "apps", "api", ".env"), "API=1\n");
+    await fs.writeFile(path.join(sourceDir, ".git", "config"), "[core]\n");
+
+    const copiedCount = await copyConfiguredEntries(
+      {
+        include: [".env", "apps/*/.env", ".git/**"],
+        exclude: ["apps/web/.env"],
+      },
+      sourceDir,
+      targetDir,
+    );
+
+    expect(copiedCount).toBe(2);
+
+    const rootEnv = await fs.readFile(path.join(targetDir, ".env"), "utf8");
+    expect(rootEnv).toContain("ROOT=1");
+
+    const apiEnv = await fs.readFile(path.join(targetDir, "apps", "api", ".env"), "utf8");
+    expect(apiEnv).toContain("API=1");
+
+    await expect(fs.access(path.join(targetDir, "apps", "web", ".env"))).rejects.toThrow();
+    await expect(fs.access(path.join(targetDir, ".git"))).rejects.toThrow();
+  });
+
+  test("returns zero when source and target are the same", async () => {
+    const dir = await createTempDir("grove-copy-same-");
+    await fs.writeFile(path.join(dir, ".env"), "A=1\n");
+
+    const copiedCount = await copyConfiguredEntries(
+      { include: [".env"] },
+      dir,
+      dir,
+    );
+
+    expect(copiedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Hey, nice tool!

Something i've had troubles with is copying .env files and other uncommited hidden files that I use for local development everytime I create a new worktree. Especially for monorepo's where it's not just a simple copy there may be many recursive directories where various files should be copied over:  .env, scripts, Taskfiles.

This PR adds a feature where .groverc can be added to the project root. This rc file determines what files get copied to to each worktree and from *where* these files are copied. atm it can be current working directory or a branch. 