### PR TITLE
chore: remove duplicate executable entry in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,6 @@ jobs:
             ./executables/grove-darwin-x64
             ./executables/grove-darwin-arm64
             ./executables/grove-windows-x64.exe
-            ./executables/grove-windows-x64.exe
 
   release:
     name: Release


### PR DESCRIPTION
Removed duplicate entry for grove-windows-x64.exe in release workflow.